### PR TITLE
Reduce the memory requirements of the test apps

### DIFF
--- a/dist-zip-application/manifest.yml
+++ b/dist-zip-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: dist-zip-application
-  memory: 512M
+  memory: 256M
   instances: 1
   path: build/distributions/dist-zip-application-1.0.0.BUILD-SNAPSHOT.zip
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/grails-application/manifest.yml
+++ b/grails-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: grails-application
-  memory: 1G
+  memory: 512M
   instances: 1
   path: target/grails-application-1.0.0.BUILD-SNAPSHOT.war
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/groovy-application/manifest.yml
+++ b/groovy-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: groovy-application
-  memory: 768M
+  memory: 256M
   instances: 1
   path: .
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/java-main-application/manifest.yml
+++ b/java-main-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: java-main-application
-  memory: 512M
+  memory: 256M
   instances: 1
   path: build/libs/java-main-application-1.0.0.BUILD-SNAPSHOT.jar
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/play-application/manifest.yml
+++ b/play-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: play-application
-  memory: 768M
+  memory: 256M
   instances: 1
   path: target/universal/play-application-1.0.0.BUILD-SNAPSHOT.zip
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/ratpack-application/manifest.yml
+++ b/ratpack-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ratpack-application
-  memory: 768M
+  memory: 128M
   instances: 1
   path: build/distributions/ratpack-application-1.0.0.BUILD-SNAPSHOT.zip
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/spring-boot-cli-application/manifest.yml
+++ b/spring-boot-cli-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: spring-boot-cli-application
-  memory: 768M
+  memory: 256M
   instances: 1
   path: .
   buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/spring-boot-cli-jar-application/manifest.yml
+++ b/spring-boot-cli-jar-application/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: spring-boot-cli-jar-application
-  memory: 768M
+  memory: 256M
   instances: 1
   path: spring-boot-cli-jar-application-1.0.0.BUILD-SNAPSHOT.jar
   buildpack: https://github.com/cloudfoundry/java-buildpack.git


### PR DESCRIPTION
More recent versions of Cloud Foundry have lower memory requirements when
running applications. This commit reduces the memory set in the test
applications to reflect this. The applications run reliably at these new
memory levels but can not be reduced any more at this time.

[#77354806]
