### PR TITLE
test: add Spring Boot context load smoke tests and fix @Autowired wiring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
 
       - name: Build boot3 standalone module
         working-directory: java-main-application-boot3
-        run: ./gradlew bootJar -Pversion=${{ steps.version.outputs.value }}
+        run: ./gradlew test -Pversion=${{ steps.version.outputs.value }}
+
+      - name: Smoke test — verify fat jars start without wiring errors
+        run: ./gradlew :java-main-application:test :java-task-application:test
 
       - name: Collect release artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,7 @@ jobs:
 
       - name: Build boot3 standalone module
         working-directory: java-main-application-boot3
-        run: ./gradlew test -Pversion=${{ steps.version.outputs.value }}
-
-      - name: Smoke test — verify fat jars start without wiring errors
-        run: ./gradlew :java-main-application:test :java-task-application:test
+        run: ./gradlew build -Pversion=${{ steps.version.outputs.value }}
 
       - name: Collect release artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Resolve version
         id: version
@@ -41,19 +41,19 @@ jobs:
           fi
 
       - name: Set up Java 21 (Temurin)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build main modules
         run: ./gradlew build -Pversion=${{ steps.version.outputs.value }}
 
       - name: Set up Java 17 for boot3 module
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -84,7 +84,7 @@ jobs:
           ls -lh release-artifacts/
 
       - name: Create fixed release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.value }}
           name: ${{ steps.version.outputs.value }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Build main modules
-        run: ./gradlew build -Pversion=${{ steps.version.outputs.value }}
+        run: ./gradlew build -PreleaseVersion=${{ steps.version.outputs.value }}
 
       - name: Set up Java 17 for boot3 module
         uses: actions/setup-java@v5
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build boot3 standalone module
         working-directory: java-main-application-boot3
-        run: ./gradlew build -Pversion=${{ steps.version.outputs.value }}
+        run: ./gradlew build -PreleaseVersion=${{ steps.version.outputs.value }}
 
       - name: Collect release artifacts
         run: |

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -14,22 +14,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java 21 (Temurin)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build main modules
         run: ./gradlew build
 
       - name: Set up Java 17 for boot3 module
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -70,7 +70,7 @@ jobs:
           git push origin :refs/tags/v1.0.0-SNAPSHOT 2>/dev/null || true
 
       - name: Create snapshot release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v1.0.0-SNAPSHOT
           name: 1.0.0-SNAPSHOT

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -36,7 +36,10 @@ jobs:
 
       - name: Build boot3 standalone module
         working-directory: java-main-application-boot3
-        run: ./gradlew bootJar
+        run: ./gradlew test
+
+      - name: Smoke test — verify fat jars start without wiring errors
+        run: ./gradlew :java-main-application:test :java-task-application:test
 
       - name: Collect release artifacts
         run: |

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -36,10 +36,7 @@ jobs:
 
       - name: Build boot3 standalone module
         working-directory: java-main-application-boot3
-        run: ./gradlew test
-
-      - name: Smoke test — verify fat jars start without wiring errors
-        run: ./gradlew :java-main-application:test :java-task-application:test
+        run: ./gradlew build
 
       - name: Collect release artifacts
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,7 +38,7 @@ The workflow triggers automatically, derives version from the tag, builds, and p
 3. Click **Run workflow**
 
 Both paths:
-- Build all modules with `-Pversion=<version>` (no file changes needed)
+- Build all modules with `-PreleaseVersion=<version>` (no file changes needed)
 - Run tests as a quality gate
 - Create a GitHub release tagged `v<version>` with all artifacts attached
 
@@ -58,11 +58,11 @@ If you need to release without the workflow:
 2. **Or build locally** and upload artifacts by hand:
    ```bash
    # Multi-module (Java 21)
-   ./gradlew build -Pversion=1.0.0
+   ./gradlew build -PreleaseVersion=1.0.0
 
    # Standalone boot3 module (Java 17)
    cd java-main-application-boot3
-   ./gradlew bootJar -Pversion=1.0.0
+   ./gradlew bootJar -PreleaseVersion=1.0.0
    ```
 
 ---

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     group   = 'org.cloudfoundry.test'
-    version = '1.0.0-SNAPSHOT'
+    version = findProperty('releaseVersion') ?: '1.0.0-SNAPSHOT'
 
     repositories {
         mavenCentral()

--- a/core/src/main/java/org/cloudfoundry/test/core/RuntimeUtils.java
+++ b/core/src/main/java/org/cloudfoundry/test/core/RuntimeUtils.java
@@ -16,6 +16,7 @@
 
 package org.cloudfoundry.test.core;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,6 +56,7 @@ public final class RuntimeUtils {
 
     private final Map<Object, Object> systemProperties;
 
+    @Autowired
     public RuntimeUtils(Environment springEnvironment) {
         this(System.getenv(), springEnvironment, ManagementFactory.getRuntimeMXBean(), Security.getProviders(), System.getProperties());
     }

--- a/java-main-application-boot3/build.gradle
+++ b/java-main-application-boot3/build.gradle
@@ -24,8 +24,6 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-test.dependsOn(bootJar)
-
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/java-main-application-boot3/build.gradle
+++ b/java-main-application-boot3/build.gradle
@@ -19,4 +19,13 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test.dependsOn(bootJar)
+
+tasks.named('test') {
+    useJUnitPlatform()
 }

--- a/java-main-application-boot3/build.gradle
+++ b/java-main-application-boot3/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'org.cloudfoundry.test'
-version = '1.0.0-SNAPSHOT'
+version = findProperty('releaseVersion') ?: '1.0.0-SNAPSHOT'
 
 java {
     toolchain {

--- a/java-main-application-boot3/gradle/wrapper/gradle-wrapper.properties
+++ b/java-main-application-boot3/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java-main-application-boot3/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-main-application-boot3/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -17,61 +17,15 @@
 package org.cloudfoundry.test;
 
 import org.junit.jupiter.api.Test;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.springframework.boot.test.context.SpringBootTest;
 
 /**
- * Smoke test: builds the boot jar and starts it with web-application-type=none.
- * Spring Boot loads the full application context; "Started" in output means success.
- * Process is destroyed after startup (it may keep running if keep-alive is enabled).
- *
- * Run: ./gradlew test (bootJar is built first via task dependency)
+ * Verifies the Spring application context loads without bean wiring errors.
  */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class SmokeTest {
 
     @Test
-    void jarStartsWithoutErrors() throws Exception {
-        File libsDir = new File("build/libs");
-        File[] jars = libsDir.listFiles(f ->
-                f.getName().endsWith(".jar") && !f.getName().contains("-plain"));
-        assertThat(jars).as("No boot jar found in build/libs — run ./gradlew bootJar first").isNotEmpty();
-
-        File jar = jars[0];
-        String javaExec = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
-        Process process = new ProcessBuilder(
-                javaExec, "-jar", jar.getAbsolutePath(),
-                "--spring.main.web-application-type=none",
-                "--spring.main.banner-mode=off"
-        )
-                .redirectErrorStream(true)
-                .start();
-
-        StringBuilder output = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            String line;
-            long deadline = System.currentTimeMillis() + 30_000;
-            while ((line = reader.readLine()) != null) {
-                output.append(line).append('\n');
-                if (line.contains("Started ")) {
-                    return; // success
-                }
-                if (System.currentTimeMillis() > deadline) {
-                    fail("App did not start within 30s:\n%s", output);
-                }
-            }
-        } finally {
-            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
-        }
-
-        int exitCode = process.exitValue();
-        if (exitCode != 0) {
-            fail("App startup failed with exit code %d:\n%s", exitCode, output);
-        }
+    void contextLoads() {
     }
 }

--- a/java-main-application-boot3/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-main-application-boot3/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test: builds the boot jar and starts it with web-application-type=none.
+ * Spring Boot loads the full application context and exits with code 0 on success,
+ * non-zero on bean wiring or startup failures.
+ *
+ * Run: ./gradlew test (bootJar is built first via task dependency)
+ */
+class SmokeTest {
+
+    @Test
+    void jarStartsWithoutErrors() throws Exception {
+        File libsDir = new File("build/libs");
+        File[] jars = libsDir.listFiles(f ->
+                f.getName().endsWith(".jar") && !f.getName().contains("-plain"));
+        assertThat(jars).as("No boot jar found in build/libs — run ./gradlew bootJar first").isNotEmpty();
+
+        File jar = jars[0];
+        String javaExec = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        Process process = new ProcessBuilder(
+                javaExec, "-jar", jar.getAbsolutePath(),
+                "--spring.main.web-application-type=none",
+                "--spring.main.banner-mode=off"
+        )
+                .redirectErrorStream(true)
+                .start();
+
+        String output = new String(process.getInputStream().readAllBytes());
+        int exitCode = process.waitFor();
+
+        assertThat(exitCode)
+                .as("App startup failed with exit code %d:\n%s", exitCode, output)
+                .isEqualTo(0);
+    }
+}

--- a/java-main-application-boot3/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-main-application-boot3/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -18,14 +18,18 @@ package org.cloudfoundry.test;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Smoke test: builds the boot jar and starts it with web-application-type=none.
- * Spring Boot loads the full application context and exits with code 0 on success,
- * non-zero on bean wiring or startup failures.
+ * Spring Boot loads the full application context; "Started" in output means success.
+ * Process is destroyed after startup (it may keep running if keep-alive is enabled).
  *
  * Run: ./gradlew test (bootJar is built first via task dependency)
  */
@@ -48,11 +52,26 @@ class SmokeTest {
                 .redirectErrorStream(true)
                 .start();
 
-        String output = new String(process.getInputStream().readAllBytes());
-        int exitCode = process.waitFor();
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            long deadline = System.currentTimeMillis() + 30_000;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append('\n');
+                if (line.contains("Started ")) {
+                    return; // success
+                }
+                if (System.currentTimeMillis() > deadline) {
+                    fail("App did not start within 30s:\n%s", output);
+                }
+            }
+        } finally {
+            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
+        }
 
-        assertThat(exitCode)
-                .as("App startup failed with exit code %d:\n%s", exitCode, output)
-                .isEqualTo(0);
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            fail("App startup failed with exit code %d:\n%s", exitCode, output);
+        }
     }
 }

--- a/java-main-application/build.gradle
+++ b/java-main-application/build.gradle
@@ -23,5 +23,3 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
-
-test.dependsOn(bootJar)

--- a/java-main-application/build.gradle
+++ b/java-main-application/build.gradle
@@ -19,4 +19,9 @@ apply plugin: 'org.springframework.boot'
 
 dependencies {
     implementation project(':spring-common')
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
+
+test.dependsOn(bootJar)

--- a/java-main-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-main-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -17,61 +17,15 @@
 package org.cloudfoundry.test;
 
 import org.junit.jupiter.api.Test;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.springframework.boot.test.context.SpringBootTest;
 
 /**
- * Smoke test: builds the boot jar and starts it with web-application-type=none.
- * Spring Boot loads the full application context; "Started" in output means success.
- * Process is destroyed after startup (it may keep running if keep-alive is enabled).
- *
- * Run: ./gradlew test (bootJar is built first via task dependency)
+ * Verifies the Spring application context loads without bean wiring errors.
  */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class SmokeTest {
 
     @Test
-    void jarStartsWithoutErrors() throws Exception {
-        File libsDir = new File("build/libs");
-        File[] jars = libsDir.listFiles(f ->
-                f.getName().endsWith(".jar") && !f.getName().contains("-plain"));
-        assertThat(jars).as("No boot jar found in build/libs — run ./gradlew bootJar first").isNotEmpty();
-
-        File jar = jars[0];
-        String javaExec = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
-        Process process = new ProcessBuilder(
-                javaExec, "-jar", jar.getAbsolutePath(),
-                "--spring.main.web-application-type=none",
-                "--spring.main.banner-mode=off"
-        )
-                .redirectErrorStream(true)
-                .start();
-
-        StringBuilder output = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            String line;
-            long deadline = System.currentTimeMillis() + 30_000;
-            while ((line = reader.readLine()) != null) {
-                output.append(line).append('\n');
-                if (line.contains("Started ")) {
-                    return; // success
-                }
-                if (System.currentTimeMillis() > deadline) {
-                    fail("App did not start within 30s:\n%s", output);
-                }
-            }
-        } finally {
-            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
-        }
-
-        int exitCode = process.exitValue();
-        if (exitCode != 0) {
-            fail("App startup failed with exit code %d:\n%s", exitCode, output);
-        }
+    void contextLoads() {
     }
 }

--- a/java-main-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-main-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test: builds the boot jar and starts it with web-application-type=none.
+ * Spring Boot loads the full application context and exits with code 0 on success,
+ * non-zero on bean wiring or startup failures.
+ *
+ * Run: ./gradlew test (bootJar is built first via task dependency)
+ */
+class SmokeTest {
+
+    @Test
+    void jarStartsWithoutErrors() throws Exception {
+        File libsDir = new File("build/libs");
+        File[] jars = libsDir.listFiles(f ->
+                f.getName().endsWith(".jar") && !f.getName().contains("-plain"));
+        assertThat(jars).as("No boot jar found in build/libs — run ./gradlew bootJar first").isNotEmpty();
+
+        File jar = jars[0];
+        String javaExec = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        Process process = new ProcessBuilder(
+                javaExec, "-jar", jar.getAbsolutePath(),
+                "--spring.main.web-application-type=none",
+                "--spring.main.banner-mode=off"
+        )
+                .redirectErrorStream(true)
+                .start();
+
+        String output = new String(process.getInputStream().readAllBytes());
+        int exitCode = process.waitFor();
+
+        assertThat(exitCode)
+                .as("App startup failed with exit code %d:\n%s", exitCode, output)
+                .isEqualTo(0);
+    }
+}

--- a/java-main-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-main-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -18,14 +18,18 @@ package org.cloudfoundry.test;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Smoke test: builds the boot jar and starts it with web-application-type=none.
- * Spring Boot loads the full application context and exits with code 0 on success,
- * non-zero on bean wiring or startup failures.
+ * Spring Boot loads the full application context; "Started" in output means success.
+ * Process is destroyed after startup (it may keep running if keep-alive is enabled).
  *
  * Run: ./gradlew test (bootJar is built first via task dependency)
  */
@@ -48,11 +52,26 @@ class SmokeTest {
                 .redirectErrorStream(true)
                 .start();
 
-        String output = new String(process.getInputStream().readAllBytes());
-        int exitCode = process.waitFor();
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            long deadline = System.currentTimeMillis() + 30_000;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append('\n');
+                if (line.contains("Started ")) {
+                    return; // success
+                }
+                if (System.currentTimeMillis() > deadline) {
+                    fail("App did not start within 30s:\n%s", output);
+                }
+            }
+        } finally {
+            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
+        }
 
-        assertThat(exitCode)
-                .as("App startup failed with exit code %d:\n%s", exitCode, output)
-                .isEqualTo(0);
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            fail("App startup failed with exit code %d:\n%s", exitCode, output);
+        }
     }
 }

--- a/java-task-application/build.gradle
+++ b/java-task-application/build.gradle
@@ -23,5 +23,3 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
-
-test.dependsOn(bootJar)

--- a/java-task-application/build.gradle
+++ b/java-task-application/build.gradle
@@ -19,4 +19,9 @@ apply plugin: 'org.springframework.boot'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
+
+test.dependsOn(bootJar)

--- a/java-task-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-task-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -17,61 +17,15 @@
 package org.cloudfoundry.test;
 
 import org.junit.jupiter.api.Test;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.springframework.boot.test.context.SpringBootTest;
 
 /**
- * Smoke test: builds the boot jar and starts it with web-application-type=none.
- * Spring Boot loads the full application context; "Started" in output means success.
- * Process is destroyed after startup (it may keep running if keep-alive is enabled).
- *
- * Run: ./gradlew test (bootJar is built first via task dependency)
+ * Verifies the Spring application context loads without bean wiring errors.
  */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class SmokeTest {
 
     @Test
-    void jarStartsWithoutErrors() throws Exception {
-        File libsDir = new File("build/libs");
-        File[] jars = libsDir.listFiles(f ->
-                f.getName().endsWith(".jar") && !f.getName().contains("-plain"));
-        assertThat(jars).as("No boot jar found in build/libs — run ./gradlew bootJar first").isNotEmpty();
-
-        File jar = jars[0];
-        String javaExec = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
-        Process process = new ProcessBuilder(
-                javaExec, "-jar", jar.getAbsolutePath(),
-                "--spring.main.web-application-type=none",
-                "--spring.main.banner-mode=off"
-        )
-                .redirectErrorStream(true)
-                .start();
-
-        StringBuilder output = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            String line;
-            long deadline = System.currentTimeMillis() + 30_000;
-            while ((line = reader.readLine()) != null) {
-                output.append(line).append('\n');
-                if (line.contains("Started ")) {
-                    return; // success
-                }
-                if (System.currentTimeMillis() > deadline) {
-                    fail("App did not start within 30s:\n%s", output);
-                }
-            }
-        } finally {
-            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
-        }
-
-        int exitCode = process.exitValue();
-        if (exitCode != 0) {
-            fail("App startup failed with exit code %d:\n%s", exitCode, output);
-        }
+    void contextLoads() {
     }
 }

--- a/java-task-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-task-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test: builds the boot jar and starts it with web-application-type=none.
+ * Spring Boot loads the full application context and exits with code 0 on success,
+ * non-zero on bean wiring or startup failures.
+ *
+ * Run: ./gradlew test (bootJar is built first via task dependency)
+ */
+class SmokeTest {
+
+    @Test
+    void jarStartsWithoutErrors() throws Exception {
+        File libsDir = new File("build/libs");
+        File[] jars = libsDir.listFiles(f ->
+                f.getName().endsWith(".jar") && !f.getName().contains("-plain"));
+        assertThat(jars).as("No boot jar found in build/libs — run ./gradlew bootJar first").isNotEmpty();
+
+        File jar = jars[0];
+        String javaExec = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        Process process = new ProcessBuilder(
+                javaExec, "-jar", jar.getAbsolutePath(),
+                "--spring.main.web-application-type=none",
+                "--spring.main.banner-mode=off"
+        )
+                .redirectErrorStream(true)
+                .start();
+
+        String output = new String(process.getInputStream().readAllBytes());
+        int exitCode = process.waitFor();
+
+        assertThat(exitCode)
+                .as("App startup failed with exit code %d:\n%s", exitCode, output)
+                .isEqualTo(0);
+    }
+}

--- a/java-task-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
+++ b/java-task-application/src/test/java/org/cloudfoundry/test/SmokeTest.java
@@ -18,14 +18,18 @@ package org.cloudfoundry.test;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Smoke test: builds the boot jar and starts it with web-application-type=none.
- * Spring Boot loads the full application context and exits with code 0 on success,
- * non-zero on bean wiring or startup failures.
+ * Spring Boot loads the full application context; "Started" in output means success.
+ * Process is destroyed after startup (it may keep running if keep-alive is enabled).
  *
  * Run: ./gradlew test (bootJar is built first via task dependency)
  */
@@ -48,11 +52,26 @@ class SmokeTest {
                 .redirectErrorStream(true)
                 .start();
 
-        String output = new String(process.getInputStream().readAllBytes());
-        int exitCode = process.waitFor();
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            long deadline = System.currentTimeMillis() + 30_000;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append('\n');
+                if (line.contains("Started ")) {
+                    return; // success
+                }
+                if (System.currentTimeMillis() > deadline) {
+                    fail("App did not start within 30s:\n%s", output);
+                }
+            }
+        } finally {
+            process.destroyForcibly().waitFor(5, TimeUnit.SECONDS);
+        }
 
-        assertThat(exitCode)
-                .as("App startup failed with exit code %d:\n%s", exitCode, output)
-                .isEqualTo(0);
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            fail("App startup failed with exit code %d:\n%s", exitCode, output);
+        }
     }
 }


### PR DESCRIPTION
Adds `@SpringBootTest` context load tests to all three Spring Boot modules to catch bean wiring errors at build time.

## Motivation

After PR #28, the `@Autowired` annotation on `RuntimeUtils` constructor was accidentally missing, causing `BeanCreationException` at startup on Spring 7.x (two constructors, no default). These smoke tests catch such issues during `./gradlew build`.

## Changes

### Smoke tests
- Add `SmokeTest.java` to `java-main-application`, `java-task-application`, `java-main-application-boot3`
- Uses `@SpringBootTest(webEnvironment=NONE)` — loads full application context, fails on wiring errors
- Runs as part of normal `./gradlew build` (no extra CI steps needed)

### Bug fix
- Add missing `@Autowired` on `RuntimeUtils(Environment)` constructor in `core` module
- Required by Spring 7.x when multiple constructors exist

### CI updates
- Bump GitHub Actions to latest major versions (Node.js 20 deprecation fix):
  - `actions/checkout` v4 → v7
  - `actions/setup-java` v4 → v5
  - `gradle/actions/setup-gradle` v4 → v6
  - `softprops/action-gh-release` v2 → v3
- Boot3 CI step uses `./gradlew build` (runs tests + produces release artifacts)
- Upgrade boot3 Gradle wrapper 8.14 → 9.6.1 (Java 25 compatibility)

### Test dependencies added
- `spring-boot-starter-test` + `junit-platform-launcher` to all three app modules